### PR TITLE
Tosca CT integration

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -125,6 +125,9 @@ type EVM struct {
 	// available gas is calculated in gasCall* according to the 63/64 rule and later
 	// applied in opCall*.
 	callGasTemp uint64
+
+	// An optional override to intercept EVM calls.
+	CallContext CallContextInterceptor
 }
 
 // NewEVM returns a new EVM. The returned EVM is not thread safe and should
@@ -181,6 +184,9 @@ func (evm *EVM) Interpreter() *EVMInterpreter {
 // the necessary steps to create accounts and reverses the state in case of an
 // execution error or failed value transfer.
 func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas uint64, value *uint256.Int) (ret []byte, leftOverGas uint64, err error) {
+	if evm.CallContext != nil {
+		return evm.CallContext.Call(evm, caller, addr, input, new(big.Int).SetUint64(gas), value.ToBig())
+	}
 	// Capture the tracer start/end events in debug mode
 	if evm.Config.Tracer != nil {
 		evm.captureBegin(evm.depth, CALL, caller.Address(), addr, input, gas, value.ToBig())
@@ -253,6 +259,9 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 // CallCode differs from Call in the sense that it executes the given address'
 // code with the caller as context.
 func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, gas uint64, value *uint256.Int) (ret []byte, leftOverGas uint64, err error) {
+	if evm.CallContext != nil {
+		return evm.CallContext.CallCode(evm, caller, addr, input, new(big.Int).SetUint64(gas), value.ToBig())
+	}
 	// Invoke tracer hooks that signal entering/exiting a call frame
 	if evm.Config.Tracer != nil {
 		evm.captureBegin(evm.depth, CALLCODE, caller.Address(), addr, input, gas, value.ToBig())
@@ -304,6 +313,9 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 // DelegateCall differs from CallCode in the sense that it executes the given address'
 // code with the caller as context and the caller is set to the caller of the caller.
 func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []byte, gas uint64) (ret []byte, leftOverGas uint64, err error) {
+	if evm.CallContext != nil {
+		return evm.CallContext.DelegateCall(evm, caller, addr, input, new(big.Int).SetUint64(gas))
+	}
 	// Invoke tracer hooks that signal entering/exiting a call frame
 	if evm.Config.Tracer != nil {
 		// NOTE: caller must, at all times be a contract. It should never happen
@@ -349,6 +361,9 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 // Opcodes that attempt to perform such modifications will result in exceptions
 // instead of performing the modifications.
 func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte, gas uint64) (ret []byte, leftOverGas uint64, err error) {
+	if evm.CallContext != nil {
+		return evm.CallContext.StaticCall(evm, caller, addr, input, new(big.Int).SetUint64(gas))
+	}
 	// Invoke tracer hooks that signal entering/exiting a call frame
 	if evm.Config.Tracer != nil {
 		evm.captureBegin(evm.depth, STATICCALL, caller.Address(), addr, input, gas, nil)
@@ -520,6 +535,9 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 
 // Create creates a new contract using code as deployment code.
 func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *uint256.Int) (ret []byte, contractAddr common.Address, leftOverGas uint64, err error) {
+	if evm.CallContext != nil {
+		return evm.CallContext.Create(evm, caller, code, new(big.Int).SetUint64(gas), value.ToBig())
+	}
 	contractAddr = crypto.CreateAddress(caller.Address(), evm.StateDB.GetNonce(caller.Address()))
 	return evm.create(caller, &codeAndHash{code: code}, gas, value, contractAddr, CREATE)
 }
@@ -529,6 +547,9 @@ func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *uint2
 // The different between Create2 with Create is Create2 uses keccak256(0xff ++ msg.sender ++ salt ++ keccak256(init_code))[12:]
 // instead of the usual sender-and-nonce-hash as the address where the contract is initialized at.
 func (evm *EVM) Create2(caller ContractRef, code []byte, gas uint64, endowment *uint256.Int, salt *uint256.Int) (ret []byte, contractAddr common.Address, leftOverGas uint64, err error) {
+	if evm.CallContext != nil {
+		return evm.CallContext.Create2(evm, caller, code, new(big.Int).SetUint64(gas), endowment.ToBig(), salt)
+	}
 	codeAndHash := &codeAndHash{code: code}
 	contractAddr = crypto.CreateAddress2(caller.Address(), salt.Bytes32(), codeAndHash.Hash().Bytes())
 	return evm.create(caller, codeAndHash, gas, endowment, contractAddr, CREATE2)

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -116,15 +116,16 @@ type EVM struct {
 	// virtual machine configuration options used to initialise the
 	// evm.
 	Config Config
-	// global (to this context) ethereum virtual machine
-	// used throughout the execution of the tx.
-	interpreter *EVMInterpreter
 	// abort is used to abort the EVM calling operations
 	abort atomic.Bool
 	// callGasTemp holds the gas available for the current call. This is needed because the
 	// available gas is calculated in gasCall* according to the 63/64 rule and later
 	// applied in opCall*.
 	callGasTemp uint64
+
+	// global (to this context) ethereum virtual machine
+	// used throughout the execution of the tx.
+	interpreter Interpreter
 
 	// An optional override to intercept EVM calls.
 	CallInterceptor CallContextInterceptor
@@ -152,7 +153,7 @@ func NewEVM(blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig
 		chainConfig: chainConfig,
 		chainRules:  chainConfig.Rules(blockCtx.BlockNumber, blockCtx.Random != nil, blockCtx.Time),
 	}
-	evm.interpreter = NewEVMInterpreter(evm)
+	evm.interpreter = NewInterpreter(config.InterpreterImpl, evm, config)
 	return evm
 }
 
@@ -175,7 +176,7 @@ func (evm *EVM) Cancelled() bool {
 }
 
 // Interpreter returns the current interpreter
-func (evm *EVM) Interpreter() *EVMInterpreter {
+func (evm *EVM) Interpreter() Interpreter {
 	return evm.interpreter
 }
 

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -117,7 +117,7 @@ func testTwoOperandOp(t *testing.T, tests []TwoOperandTestcase, opFn executionFu
 		expected := new(uint256.Int).SetBytes(common.Hex2Bytes(test.Expected))
 		stack.push(x)
 		stack.push(y)
-		opFn(&pc, evmInterpreter, &ScopeContext{nil, stack, nil})
+		opFn(&pc, evmInterpreter.(*EVMInterpreter), &ScopeContext{nil, stack, nil})
 		if len(stack.data) != 1 {
 			t.Errorf("Expected one item on stack after %v, got %d: ", name, len(stack.data))
 		}
@@ -259,7 +259,7 @@ func TestWriteExpectedValues(t *testing.T) {
 			y := new(uint256.Int).SetBytes(common.Hex2Bytes(param.y))
 			stack.push(x)
 			stack.push(y)
-			opFn(&pc, interpreter, &ScopeContext{nil, stack, nil})
+			opFn(&pc, interpreter.(*EVMInterpreter), &ScopeContext{nil, stack, nil})
 			actual := stack.pop()
 			result[i] = TwoOperandTestcase{param.x, param.y, fmt.Sprintf("%064x", actual)}
 		}
@@ -734,7 +734,7 @@ func TestRandom(t *testing.T) {
 			pc             = uint64(0)
 			evmInterpreter = env.interpreter
 		)
-		opRandom(&pc, evmInterpreter, &ScopeContext{nil, stack, nil})
+		opRandom(&pc, evmInterpreter.(*EVMInterpreter), &ScopeContext{nil, stack, nil})
 		if len(stack.data) != 1 {
 			t.Errorf("Expected one item on stack after %v, got %d: ", tt.name, len(stack.data))
 		}
@@ -776,7 +776,7 @@ func TestBlobHash(t *testing.T) {
 			evmInterpreter = env.interpreter
 		)
 		stack.push(uint256.NewInt(tt.idx))
-		opBlobHash(&pc, evmInterpreter, &ScopeContext{nil, stack, nil})
+		opBlobHash(&pc, evmInterpreter.(*EVMInterpreter), &ScopeContext{nil, stack, nil})
 		if len(stack.data) != 1 {
 			t.Errorf("Expected one item on stack after %v, got %d: ", tt.name, len(stack.data))
 		}
@@ -917,7 +917,7 @@ func TestOpMCopy(t *testing.T) {
 			mem.Resize(memorySize)
 		}
 		// Do the copy
-		opMcopy(&pc, evmInterpreter, &ScopeContext{mem, stack, nil})
+		opMcopy(&pc, evmInterpreter.(*EVMInterpreter), &ScopeContext{mem, stack, nil})
 		want := common.FromHex(strings.ReplaceAll(tc.want, " ", ""))
 		if have := mem.store; !bytes.Equal(want, have) {
 			t.Errorf("case %d: \nwant: %#x\nhave: %#x\n", i, want, have)

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -33,6 +33,8 @@ type Config struct {
 	NoBaseFee               bool  // Forces the EIP-1559 baseFee to 0 (needed for 0 price calls)
 	EnablePreimageRecording bool  // Enables recording of SHA3/keccak preimages
 	ExtraEips               []int // Additional EIPS that are to be enabled
+
+	InterpreterImpl string // The interpreter implementation to use
 }
 
 // ScopeContext contains the things that are per-call, such as stack and memory,

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -230,7 +230,6 @@ func (in *EVMInterpreter) Step(state *GethState) bool {
 	if sLen := state.Stack.len(); sLen < operation.minStack {
 		state.Err = &ErrStackUnderflow{stackLen: sLen, required: operation.minStack}
 		return false
-
 	} else if sLen > operation.maxStack {
 		state.Err = &ErrStackOverflow{stackLen: sLen, limit: operation.maxStack}
 		return false

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -147,10 +147,24 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 // It's important to note that any errors returned by the interpreter should be
 // considered a revert-and-consume-all-gas operation except for
 // ErrExecutionReverted which means revert-and-keep-gas-left.
-func (in *EVMInterpreter) run(state *InterpreterState, input []byte, readOnly bool) (ret []byte, err error) {
+func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (ret []byte, err error) {
+	state := InterpreterState{
+		Contract: contract,
+		Stack:    newstack(),
+		Memory:   NewMemory(),
+		Input:    input,
+		ReadOnly: readOnly,
+	}
 	defer func() {
-		state.finished = true
+		returnStack(state.Stack)
 	}()
+	return in.run(&state, math.MaxUint64)
+}
+
+func (in *EVMInterpreter) run(state *InterpreterState, maxSteps uint64) (ret []byte, err error) {
+	contract := state.Contract
+	input := state.Input
+	readOnly := state.ReadOnly
 
 	// Increment the call depth which is restricted to 1024
 	in.evm.depth++
@@ -163,20 +177,38 @@ func (in *EVMInterpreter) run(state *InterpreterState, input []byte, readOnly bo
 		defer func() { in.readOnly = false }()
 	}
 
-	// Reset the previous call's return data. It's unimportant to preserve the old buffer
-	// as every returning call will return new data anyway.
-	in.returnData = nil
+	// Use the InterperterState`s last call return data. If this function is called in
+	// a regular run context, this will reset the return data to nil.
+	in.returnData = state.LastCallReturnData
 
 	// Don't bother with the execution if there's no code.
-	if len(state.Contract.Code) == 0 {
+	if len(contract.Code) == 0 {
 		return nil, nil
 	}
 
-	gethState := NewGethState(state.Contract, state.Memory, state.Stack, state.pc)
-	gethState.Contract.Input = input
+	var (
+		op          OpCode // current opcode
+		mem         = state.Memory
+		stack       = state.Stack
+		callContext = &ScopeContext{
+			Memory:   mem,
+			Stack:    stack,
+			Contract: contract,
+		}
+		// For optimisation reason we're using uint64 as the program counter.
+		// It's theoretically possible to go above 2^64. The YP defines the PC
+		// to be uint256. Practically much less so feasible.
+		pc   = state.Pc // program counter
+		cost uint64
+		// copies used by tracer
+		pcCopy  uint64 // needed for the deferred EVMLogger
+		gasCopy uint64 // for EVMLogger to log gas remaining before execution
+		logged  bool   // deferred EVMLogger should ignore already logged steps
+		res     []byte // result of the opcode execution function
+		debug   = in.evm.Config.Tracer != nil
+	)
 
-	debug := in.evm.Config.Tracer != nil
-	var logged bool
+	contract.Input = input
 
 	if debug {
 		defer func() { // this deferred method handles exit-with-error
@@ -184,124 +216,105 @@ func (in *EVMInterpreter) run(state *InterpreterState, input []byte, readOnly bo
 				return
 			}
 			if !logged && in.evm.Config.Tracer.OnOpcode != nil {
-				in.evm.Config.Tracer.OnOpcode(gethState.pcCopy, byte(gethState.op), gethState.gasCopy, gethState.cost, gethState.CallContext, in.returnData, in.evm.depth, VMErrorFromErr(err))
+				in.evm.Config.Tracer.OnOpcode(pcCopy, byte(op), gasCopy, cost, callContext, in.returnData, in.evm.depth, VMErrorFromErr(err))
 			}
 			if logged && in.evm.Config.Tracer.OnFault != nil {
-				in.evm.Config.Tracer.OnFault(gethState.pcCopy, byte(gethState.op), gethState.gasCopy, gethState.cost, gethState.CallContext, in.evm.depth, VMErrorFromErr(err))
+				in.evm.Config.Tracer.OnFault(pcCopy, byte(op), gasCopy, cost, callContext, in.evm.depth, VMErrorFromErr(err))
 			}
 		}()
 	}
-
 	// The Interpreter main run loop (contextual). This loop runs until either an
 	// explicit STOP, RETURN or SELFDESTRUCT is executed, an error occurred during
 	// the execution of one of the operations or until the done flag is set by the
-	// parent context.
-	steps := 0
-	for {
-		steps++
-		if in.evm.abort.Load() {
-			break
-		}
-
-		if !in.Step(gethState) {
-			break
-		}
-	}
-
-	if gethState.Err == errStopToken {
-		gethState.Err = nil // clear stop token error
-	}
-
-	return gethState.Result, gethState.Err
-}
-
-func (in *EVMInterpreter) Step(state *GethState) bool {
-	debug := in.evm.Config.Tracer != nil
-	if debug {
-		// Capture pre-execution values for tracing.
-		state.logged, state.pcCopy, state.gasCopy = false, state.Pc, state.Contract.Gas
-	}
-	// Get the operation from the jump table and validate the stack to ensure there are
-	// enough stack items available to perform the operation.
-	state.op = state.Contract.GetOp(state.Pc)
-	operation := in.table[state.op]
-	cost := operation.constantGas // For tracing
-	// Validate stack
-	if sLen := state.Stack.len(); sLen < operation.minStack {
-		state.Err = &ErrStackUnderflow{stackLen: sLen, required: operation.minStack}
-		return false
-	} else if sLen > operation.maxStack {
-		state.Err = &ErrStackOverflow{stackLen: sLen, limit: operation.maxStack}
-		return false
-	}
-	if !state.Contract.UseGas(cost, in.evm.Config.Tracer, tracing.GasChangeIgnored) {
-		state.Err = ErrOutOfGas
-		return false
-	}
-
-	if operation.dynamicGas != nil {
-		// All ops with a dynamic memory usage also has a dynamic gas cost.
-		var memorySize uint64
-		// calculate the new memory size and expand the memory to fit
-		// the operation
-		// Memory check needs to be done prior to evaluating the dynamic gas portion,
-		// to detect calculation overflows
-		if operation.memorySize != nil {
-			memSize, overflow := operation.memorySize(state.Stack)
-			if overflow {
-				state.Err = ErrGasUintOverflow
-				return false
-			}
-			// memory is expanded in words of 32 bytes. Gas
-			// is also calculated in words.
-			if memorySize, overflow = math.SafeMul(toWordSize(memSize), 32); overflow {
-				state.Err = ErrGasUintOverflow
-				return false
-			}
-		}
-		// Consume the gas and return an error if not enough gas is available.
-		// cost is explicitly set so that the capture state defer method can get the proper cost
-		var dynamicCost uint64
-		dynamicCost, state.Err = operation.dynamicGas(in.evm, state.Contract, state.Stack, state.Memory, memorySize)
-		cost += dynamicCost // for tracing
-		if state.Err != nil {
-			state.Err = fmt.Errorf("%w: %v", ErrOutOfGas, state.Err)
-			return false
-		}
-		if !state.Contract.UseGas(dynamicCost, in.evm.Config.Tracer, tracing.GasChangeIgnored) {
-			state.Err = ErrOutOfGas
-			return false
-		}
-
-		// Do tracing before memory expansion
+	// parent context. It also may stop after a given step limit for testing.
+	for steps := uint64(0); steps < maxSteps; steps++ {
 		if debug {
+			// Capture pre-execution values for tracing.
+			logged, pcCopy, gasCopy = false, pc, contract.Gas
+		}
+		// Get the operation from the jump table and validate the stack to ensure there are
+		// enough stack items available to perform the operation.
+		op = contract.GetOp(pc)
+		operation := in.table[op]
+		cost = operation.constantGas // For tracing
+		// Validate stack
+		if sLen := stack.len(); sLen < operation.minStack {
+			return nil, &ErrStackUnderflow{stackLen: sLen, required: operation.minStack}
+		} else if sLen > operation.maxStack {
+			return nil, &ErrStackOverflow{stackLen: sLen, limit: operation.maxStack}
+		}
+		if !contract.UseGas(cost, in.evm.Config.Tracer, tracing.GasChangeIgnored) {
+			return nil, ErrOutOfGas
+		}
+
+		if operation.dynamicGas != nil {
+			// All ops with a dynamic memory usage also has a dynamic gas cost.
+			var memorySize uint64
+			// calculate the new memory size and expand the memory to fit
+			// the operation
+			// Memory check needs to be done prior to evaluating the dynamic gas portion,
+			// to detect calculation overflows
+			if operation.memorySize != nil {
+				memSize, overflow := operation.memorySize(stack)
+				if overflow {
+					return nil, ErrGasUintOverflow
+				}
+				// memory is expanded in words of 32 bytes. Gas
+				// is also calculated in words.
+				if memorySize, overflow = math.SafeMul(toWordSize(memSize), 32); overflow {
+					return nil, ErrGasUintOverflow
+				}
+			}
+			// Consume the gas and return an error if not enough gas is available.
+			// cost is explicitly set so that the capture state defer method can get the proper cost
+			var dynamicCost uint64
+			dynamicCost, err = operation.dynamicGas(in.evm, contract, stack, mem, memorySize)
+			cost += dynamicCost // for tracing
+			if err != nil {
+				return nil, fmt.Errorf("%w: %v", ErrOutOfGas, err)
+			}
+			if !contract.UseGas(dynamicCost, in.evm.Config.Tracer, tracing.GasChangeIgnored) {
+				return nil, ErrOutOfGas
+			}
+
+			// Do tracing before memory expansion
+			if debug {
+				if in.evm.Config.Tracer.OnGasChange != nil {
+					in.evm.Config.Tracer.OnGasChange(gasCopy, gasCopy-cost, tracing.GasChangeCallOpCode)
+				}
+				if in.evm.Config.Tracer.OnOpcode != nil {
+					in.evm.Config.Tracer.OnOpcode(pc, byte(op), gasCopy, cost, callContext, in.returnData, in.evm.depth, VMErrorFromErr(err))
+					logged = true
+				}
+			}
+			if memorySize > 0 {
+				mem.Resize(memorySize)
+			}
+		} else if debug {
 			if in.evm.Config.Tracer.OnGasChange != nil {
-				in.evm.Config.Tracer.OnGasChange(state.gasCopy, state.gasCopy-cost, tracing.GasChangeCallOpCode)
+				in.evm.Config.Tracer.OnGasChange(gasCopy, gasCopy-cost, tracing.GasChangeCallOpCode)
 			}
 			if in.evm.Config.Tracer.OnOpcode != nil {
-				in.evm.Config.Tracer.OnOpcode(state.Pc, byte(state.op), state.gasCopy, cost, state.CallContext, in.returnData, in.evm.depth, VMErrorFromErr(state.Err))
-				state.logged = true
+				in.evm.Config.Tracer.OnOpcode(pc, byte(op), gasCopy, cost, callContext, in.returnData, in.evm.depth, VMErrorFromErr(err))
+				logged = true
 			}
 		}
-		if memorySize > 0 {
-			state.Memory.Resize(memorySize)
+
+		// execute the operation
+		res, err = operation.execute(&pc, in, callContext)
+		if err != nil {
+			break
 		}
-	} else if debug {
-		if in.evm.Config.Tracer.OnGasChange != nil {
-			in.evm.Config.Tracer.OnGasChange(state.gasCopy, state.gasCopy-cost, tracing.GasChangeCallOpCode)
-		}
-		if in.evm.Config.Tracer.OnOpcode != nil {
-			in.evm.Config.Tracer.OnOpcode(state.Pc, byte(state.op), state.gasCopy, cost, state.CallContext, in.returnData, in.evm.depth, VMErrorFromErr(state.Err))
-			state.logged = true
-		}
+		pc++
 	}
 
-	// execute the operation
-	state.Result, state.Err = operation.execute(&state.Pc, in, state.CallContext)
-	if state.Err != nil {
-		return false
-	}
-	state.Pc++
+	// Copy information back into passed Interpreter state.
+	state.Pc = pc
+	state.Error = err
 
-	return state.Err == nil
+	if err == errStopToken {
+		err = nil // clear stop token error
+	}
+
+	return res, err
 }

--- a/core/vm/tosca_ct_integration.go
+++ b/core/vm/tosca_ct_integration.go
@@ -1,0 +1,165 @@
+package vm
+
+import (
+	"math/big"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/holiman/uint256"
+)
+
+// Error
+var ErrStopToken = errStopToken
+
+// Gas table
+func MemoryGasCost(mem *Memory, wordSize uint64) (uint64, error) {
+	return memoryGasCost(mem, wordSize)
+}
+
+// Stack
+func NewStack() *Stack {
+	return newstack()
+}
+
+func (st *Stack) Len() int {
+	return st.len()
+}
+
+func (st *Stack) Push(d *uint256.Int) {
+	st.push(d)
+}
+
+// EVM
+func (evm *EVM) GetDepth() int {
+	return evm.depth
+}
+
+func (evm *EVM) SetDepth(depth int) {
+	evm.depth = depth
+}
+
+// Interpreter
+func (g *EVMInterpreter) SetLastCallReturnData(data []byte) {
+	g.returnData = data
+}
+
+func (g *EVMInterpreter) GetLastCallReturnData() []byte {
+	return g.returnData
+}
+
+func (g *EVMInterpreter) SetReadOnly(readOnly bool) {
+	g.readOnly = readOnly
+}
+
+func (g *EVMInterpreter) IsReadOnly() bool {
+	return g.readOnly
+}
+
+// CallContext Call interceptor
+
+// CallContext provides a basic interface for the EVM calling conventions. The EVM
+// depends on this context being implemented for doing subcalls and initialising new EVM contracts.
+type CallContextInterceptor interface {
+	// Call calls another contract.
+	Call(env *EVM, me ContractRef, addr common.Address, data []byte, gas, value *big.Int) ([]byte, uint64, error)
+	// CallCode takes another contracts code and execute within our own context
+	CallCode(env *EVM, me ContractRef, addr common.Address, data []byte, gas, value *big.Int) ([]byte, uint64, error)
+	// DelegateCall is same as CallCode except sender and value is propagated from parent to child scope
+	DelegateCall(env *EVM, me ContractRef, addr common.Address, data []byte, gas *big.Int) ([]byte, uint64, error)
+	// Create creates a new contract
+	Create(env *EVM, me ContractRef, data []byte, gas, value *big.Int) ([]byte, common.Address, uint64, error)
+
+	StaticCall(env *EVM, me ContractRef, addr common.Address, input []byte, gas *big.Int) ([]byte, uint64, error)
+	Create2(env *EVM, me ContractRef, code []byte, gas *big.Int, value *big.Int, salt *uint256.Int) ([]byte, common.Address, uint64, error)
+}
+
+// Interpreter interface
+// EVMInterpreter defines an interface for different interpreter implementations.
+type GethEVMInterpreter interface {
+	// Run the contract's code with the given input data and returns the return byte-slice
+	// and an error if one occurred.
+	Run(contract *Contract, input []byte, readOnly bool) (ret []byte, err error)
+}
+
+type InterpreterFactory func(evm *EVM, cfg Config) GethEVMInterpreter
+
+var interpreter_registry = map[string]InterpreterFactory{}
+
+func RegisterInterpreterFactory(name string, factory InterpreterFactory) {
+	interpreter_registry[strings.ToLower(name)] = factory
+}
+
+func NewInterpreter(name string, evm *EVM, cfg Config) GethEVMInterpreter {
+	factory, found := interpreter_registry[strings.ToLower(name)]
+	if !found {
+		log.Error("no factory for interpreter registered", "name", name)
+	}
+	return factory(evm, cfg)
+}
+
+func init() {
+	factory := func(evm *EVM, cfg Config) GethEVMInterpreter {
+		return NewEVMInterpreter(evm)
+	}
+	RegisterInterpreterFactory("", factory)
+	RegisterInterpreterFactory("geth", factory)
+}
+
+// Abstracted interpreter with single step execution.
+
+// GethState represents the internal state of the interpreter.
+type GethState struct {
+	Contract *Contract // processed contract
+	Memory   *Memory   // bound memory
+	Stack    *Stack    // local stack
+	// For optimisation reason we're using uint64 as the program counter.
+	// It's theoretically possible to go above 2^64. The YP defines the PC
+	// to be uint256. Practically much less so feasible.
+	Pc          uint64 // program counter
+	Result      []byte // result of the opcode execution function
+	Err         error
+	CallContext *ScopeContext
+	ReadOnly    bool
+	Halted      bool
+
+	op   OpCode // current opcode
+	cost uint64
+
+	// copies used by tracer
+	pcCopy  uint64 // needed for the deferred Tracer
+	gasCopy uint64 // for Tracer to log gas remaining before execution
+	logged  bool   // deferred Tracer should ignore already logged steps
+}
+
+func NewGethState(contract *Contract, memory *Memory, stack *Stack, Pc uint64) *GethState {
+	return &GethState{
+		Contract: contract,
+		Memory:   memory,
+		Stack:    stack,
+		Pc:       Pc,
+		CallContext: &ScopeContext{
+			Memory:   memory,
+			Stack:    stack,
+			Contract: contract,
+		},
+	}
+}
+
+type InterpreterState struct {
+	Contract *Contract
+	Stack    *Stack
+	Memory   *Memory
+	pc       uint64
+	finished bool
+}
+
+func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (ret []byte, err error) {
+	state := InterpreterState{
+		Contract: contract,
+		Stack:    NewStack(),
+		Memory:   NewMemory(),
+	}
+	defer returnStack(state.Stack)
+	return in.run(&state, input, readOnly)
+}

--- a/core/vm/tosca_ct_integration.go
+++ b/core/vm/tosca_ct_integration.go
@@ -1,7 +1,6 @@
 package vm
 
 import (
-	"math/big"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -57,21 +56,20 @@ func (g *EVMInterpreter) IsReadOnly() bool {
 }
 
 // CallContext Call interceptor
-
 // CallContext provides a basic interface for the EVM calling conventions. The EVM
 // depends on this context being implemented for doing subcalls and initialising new EVM contracts.
 type CallContextInterceptor interface {
 	// Call calls another contract.
-	Call(env *EVM, me ContractRef, addr common.Address, data []byte, gas, value *big.Int) ([]byte, uint64, error)
+	Call(env *EVM, me ContractRef, addr common.Address, data []byte, gas uint64, value *uint256.Int) ([]byte, uint64, error)
 	// CallCode takes another contracts code and execute within our own context
-	CallCode(env *EVM, me ContractRef, addr common.Address, data []byte, gas, value *big.Int) ([]byte, uint64, error)
+	CallCode(env *EVM, me ContractRef, addr common.Address, data []byte, gas uint64, value *uint256.Int) ([]byte, uint64, error)
 	// DelegateCall is same as CallCode except sender and value is propagated from parent to child scope
-	DelegateCall(env *EVM, me ContractRef, addr common.Address, data []byte, gas *big.Int) ([]byte, uint64, error)
+	DelegateCall(env *EVM, me ContractRef, addr common.Address, data []byte, gas uint64) ([]byte, uint64, error)
 	// Create creates a new contract
-	Create(env *EVM, me ContractRef, data []byte, gas, value *big.Int) ([]byte, common.Address, uint64, error)
+	Create(env *EVM, me ContractRef, data []byte, gas uint64, value *uint256.Int) ([]byte, common.Address, uint64, error)
 
-	StaticCall(env *EVM, me ContractRef, addr common.Address, input []byte, gas *big.Int) ([]byte, uint64, error)
-	Create2(env *EVM, me ContractRef, code []byte, gas *big.Int, value *big.Int, salt *uint256.Int) ([]byte, common.Address, uint64, error)
+	StaticCall(env *EVM, me ContractRef, addr common.Address, input []byte, gas uint64) ([]byte, uint64, error)
+	Create2(env *EVM, me ContractRef, code []byte, gas uint64, value *uint256.Int, salt *uint256.Int) ([]byte, common.Address, uint64, error)
 }
 
 // Interpreter interface
@@ -107,7 +105,6 @@ func init() {
 }
 
 // Abstracted interpreter with single step execution.
-
 // GethState represents the internal state of the interpreter.
 type GethState struct {
 	Contract *Contract // processed contract

--- a/core/vm/tosca_integration_test.go
+++ b/core/vm/tosca_integration_test.go
@@ -1,0 +1,44 @@
+package vm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInterpreterFactory(t *testing.T) {
+	evm := &EVM{}
+	cfg := Config{}
+
+	interpreter := NewInterpreter("", evm, cfg)
+	if interpreter == nil {
+		t.Error("Expected interpreter to be created, but got nil")
+	}
+	interpreter = NewInterpreter("geth", evm, cfg)
+	if interpreter == nil {
+		t.Error("Expected interpreter to be created, but got nil")
+	}
+	asserted := assert.Panics(t, func() { NewInterpreter("invalid", evm, cfg) })
+	if !asserted {
+		t.Error("Expected panic with invalid interpreter name")
+	}
+}
+
+func TestInterpreterFactory_RegisterInterpreter(t *testing.T) {
+	evm := &EVM{}
+	cfg := Config{}
+	correctFactoryIsCalled := false
+
+	RegisterInterpreterFactory("newInterpreter", func(evm *EVM, cfg Config) Interpreter {
+		correctFactoryIsCalled = true
+		return NewEVMInterpreter(evm)
+	})
+
+	interpreter := NewInterpreter("newInterpreter", evm, cfg)
+	if interpreter == nil {
+		t.Error("Expected interpreter to be created, but got nil")
+	}
+	if !correctFactoryIsCalled {
+		t.Error("Wrong interpreter factory has been called")
+	}
+}


### PR DESCRIPTION
This PR applies the required changes to use this geth fork with the Tosca CT.
Mainly the changes consist of adding a public wrapper to private functions and moving the interpreter loop into a separate Step function.
By implementing most of the changes in a newly introduced file it should be possible to keep the geth version up to date without major code changes.